### PR TITLE
2.8.1 h. 顯示林班地範圍

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bootstrap": "^4.1.3",
     "handsontable": "^5.0.2",
     "highcharts": "^6.1.4",
+    "idx": "^2.5.2",
     "jquery": "^3.3.1",
     "js-cookie": "^2.2.0",
     "leaflet.icon.glyph": "^0.2.0",

--- a/src/pages/index/views/Project.vue
+++ b/src/pages/index/views/Project.vue
@@ -650,9 +650,6 @@ export default {
       }, 100);
     },
     species: 'loadPieChart',
-    'mapInfo.center': function(newVal, oldVal) {
-      console.log('xxx', newVal, oldVal);
-    },
   },
   computed: {
     ...project.mapState([
@@ -946,6 +943,7 @@ export default {
       }
     },
     // 取得林地範圍
+    // 判斷是否重送 api
     shouldReloadForestBoundary() {
       if (!this.mapInfo || !this.mapInfo.center) {
         return false;
@@ -962,6 +960,7 @@ export default {
       };
       return true;
     },
+    // call api
     loadForestBoundaryByMapCenter() {
       if (this.shouldReloadForestBoundary()) {
         const {
@@ -974,6 +973,7 @@ export default {
         });
       }
     },
+    // 移動 map 時 call api
     centerUpdated() {
       this.loadForestBoundaryByMapCenter();
     },

--- a/src/service/api.js
+++ b/src/service/api.js
@@ -7,3 +7,4 @@ export * from './modules/user';
 export * from './modules/notification';
 export * from './modules/uploadSession';
 export * from './modules/annotationRevision';
+export * from './modules/forestBoundary';

--- a/src/service/modules/forestBoundary.js
+++ b/src/service/modules/forestBoundary.js
@@ -1,0 +1,16 @@
+import fetchWrap from '../../util/fetch';
+
+const getForestBoundary = async ({ decimalLatitude, decimalLongitude }) => {
+  const res = await fetchWrap({
+    url: '/forest-compartment-boundary',
+    method: 'POST',
+    body: {
+      decimalLatitude,
+      decimalLongitude,
+    },
+  });
+
+  return res.ret || {};
+};
+
+export { getForestBoundary };

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -8,6 +8,7 @@ import media from './modules/media';
 import cameraLocation from './modules/cameraLocation';
 import uploadSession from './modules/uploadSession';
 import annotationRevision from './modules/annotationRevision';
+import forestBoundary from './modules/forestBoundary';
 
 Vue.use(Vuex);
 
@@ -20,6 +21,7 @@ export default new Vuex.Store({
     cameraLocation,
     uploadSession,
     annotationRevision,
+    forestBoundary,
   },
   state: {
     pageLock: false,

--- a/src/stores/modules/forestBoundary.js
+++ b/src/stores/modules/forestBoundary.js
@@ -10,8 +10,7 @@ export const mutations = {
     state.forestBoundary = payload.map(obj => ({
       id: obj._id,
       visible: true,
-      // TODO: response format check: https://github.com/TaiBIF/camera-trap-api/issues/45
-      points: idx(obj, _ => _.geometry.coordinates[0][0]).map(coordinate => ({
+      points: idx(obj, _ => _.geometry.coordinates[0]).map(coordinate => ({
         lng: coordinate[0],
         lat: coordinate[1],
       })),

--- a/src/stores/modules/forestBoundary.js
+++ b/src/stores/modules/forestBoundary.js
@@ -9,7 +9,6 @@ export const mutations = {
   updateForestBoundary(state, payload) {
     state.forestBoundary = payload.map(obj => ({
       id: obj._id,
-      visible: true,
       points: idx(obj, _ => _.geometry.coordinates[0]).map(coordinate => ({
         lng: coordinate[0],
         lat: coordinate[1],

--- a/src/stores/modules/forestBoundary.js
+++ b/src/stores/modules/forestBoundary.js
@@ -1,0 +1,40 @@
+import idx from 'idx';
+import { getForestBoundary } from '../../service/api';
+
+export const getters = {
+  forestBoundary: state => state.forestBoundary,
+};
+
+export const mutations = {
+  updateForestBoundary(state, payload) {
+    state.forestBoundary = payload.map(obj => ({
+      id: obj._id,
+      visible: true,
+      // TODO: response format check: https://github.com/TaiBIF/camera-trap-api/issues/45
+      points: idx(obj, _ => _.geometry.coordinates[0][0]).map(coordinate => ({
+        lng: coordinate[0],
+        lat: coordinate[1],
+      })),
+    }));
+  },
+};
+
+export const actions = {
+  async loadForestBoundary({ commit }, { decimalLatitude, decimalLongitude }) {
+    const payload = await getForestBoundary({
+      decimalLatitude,
+      decimalLongitude,
+    });
+    commit('updateForestBoundary', payload);
+  },
+};
+
+export default {
+  namespaced: true,
+  state: {
+    forestBoundary: [],
+  },
+  getters,
+  mutations,
+  actions,
+};


### PR DESCRIPTION
close #18 
* `POST /forest-compartment-boundary` 取得林班地範圍
* component mounted & 移動地圖時 call api
* 加入 idx 套件來處理 nested response format: https://github.com/facebookincubator/idx#readme
```
idx(props, _ => _.user.friends[0].friends)
```

![zoom](https://user-images.githubusercontent.com/13633490/49337493-652b0400-f64e-11e8-8680-b7a1f4ea1421.gif)
