### PR TITLE
paging by day at backend

### DIFF
--- a/src/sass/globals/_page.sass
+++ b/src/sass/globals/_page.sass
@@ -291,8 +291,8 @@
 
     .empty-result
         text-align: center
-        padding-top: 90px
-        padding-bottom: 90px
+        padding-top: 5%
+        padding-bottom: 5%
 
         h5
             margin-top: 10px
@@ -684,6 +684,24 @@
         flex-wrap: wrap
 
         .btn-group.btn-grayscale
+            .btn.btn-xs
+                vertical-align: middle
+                border-color: $gray
+                line-height: 15px
+                height: 25px
+                padding-left: 5px
+                padding-right: 5px
+
+                > *
+                    vertical-align: middle
+
+                .icon
+                    margin-right: 3px
+
+                .text
+                    padding-right: 3px
+                    border-right: 1px solid transparentize($gray, 0.8)
+
             .btn.btn-sm
                 vertical-align: middle
                 border-color: $gray
@@ -823,7 +841,7 @@
 
                 input.form-control
                     font-size: 13px
-                    width: 40px
+                    width: 80px
                     height: 24px
                     color: $black
                     text-align: center
@@ -1050,3 +1068,9 @@
         padding: 10px 20px
         line-height: 1.5
         background: #F3F2F2
+
+.no-padding-left
+    padding-left: 0px
+
+.no-padding-right
+    padding-right: 0px

--- a/src/service/modules/media.js
+++ b/src/service/modules/media.js
@@ -1,6 +1,9 @@
 import fetchWrap from '../../util/fetch';
 
 const getSiteData = async payload => {
+  if (payload.projectOnly) {
+    return [];
+  }
   const res = await fetchWrap({
     url: '/media/annotation/query',
     method: 'POST',
@@ -68,4 +71,32 @@ const deleteToken = async payload => {
   return res;
 };
 
-export { getSiteData, updateAnnotation, replicateToken, deleteToken };
+const countSiteData = async payload => {
+  const { query } = payload;
+  const res = await fetchWrap({
+    url: '/media/annotation/doc-count',
+    method: 'POST',
+    body: Object.assign({}, { query }),
+  });
+
+  return res.count;
+};
+
+const scanSiteData = async payload => {
+  const res = await fetchWrap({
+    url: '/media/annotation/query',
+    method: 'POST',
+    body: payload,
+  });
+
+  return res;
+};
+
+export {
+  getSiteData,
+  updateAnnotation,
+  replicateToken,
+  deleteToken,
+  countSiteData,
+  scanSiteData,
+};


### PR DESCRIPTION
- 分頁改至後端進行, related to #107 
- 以天數分頁，取代筆數分頁 (不用 skip+limit 的原因請參考 [stackoverflow/mongodb-paging](https://stackoverflow.com/questions/5049992/mongodb-paging))
- 使用者選或切換到沒資料的分頁時，採用暫時稱為 scan 的機制自動幫使用者切換到鄰近有資料的分頁。
- 改善部分效能問題 (使用 async/await 的時機與輕量化部分qeuries、api calls)
- 解決 Handsontable height 不正常問題, related to #99 
- 調整部分版面顯示 bugs