### PR TITLE
修正首頁右上角navbar在小尺寸顯示器上icon的顯示圖形

### DIFF
--- a/src/components/Header/TheHeader.vue
+++ b/src/components/Header/TheHeader.vue
@@ -8,7 +8,7 @@
       >Camara Capture</a>
       <button
         v-if="!isLogin"
-        class="navbar-toggler"
+        class="navbar-toggler collapsed"
         type="button"
         data-toggle="collapse"
         data-target="#navbarSupportedContent"


### PR DESCRIPTION
根據 #170 所描述，進入首頁時且在小尺寸下瀏覽(手機)，右上角的navbar的初始icon為"x"，在ux上會讓使用者不知道要如何操作，舉而代之的應該是像下方的圖示
![image](https://user-images.githubusercontent.com/15647660/52166510-2813e880-2749-11e9-8d03-2437248d5e47.png)

This PR resolve #170 , 所以當未點擊的時候，其 icon為上述提到的漢堡選單
